### PR TITLE
feat(sp8.8): use vars.RUNNER_LABEL for runner fallback (Option C)

### DIFF
--- a/.github/workflows/action-netlify-deploy.yml
+++ b/.github/workflows/action-netlify-deploy.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     #runs-on: self-hosted
     steps:
       - name: Check out the repo

--- a/.github/workflows/bloginspritation-converter.yml
+++ b/.github/workflows/bloginspritation-converter.yml
@@ -10,8 +10,7 @@ on:
       
 jobs:
   build-and-publish:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/bright-backstage.yml
+++ b/.github/workflows/bright-backstage.yml
@@ -9,8 +9,7 @@ on:
       
 jobs:
   build-and-publish-docker:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/bright-duplicati.yml
+++ b/.github/workflows/bright-duplicati.yml
@@ -9,8 +9,7 @@ on:
       
 jobs:
   build-and-publish-seo-analysis:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/bright-monicahq.yml
+++ b/.github/workflows/bright-monicahq.yml
@@ -9,8 +9,7 @@ on:
       
 jobs:
   build-and-publish-monicahq-docker:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   build_and_push:
     name: Build and Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/build_and_publish_indexation_docker.yml
+++ b/.github/workflows/build_and_publish_indexation_docker.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-publish-indexation-analyzer:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/build_and_publish_jekyll_action_docker.yml
+++ b/.github/workflows/build_and_publish_jekyll_action_docker.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build-and-publish-jekyll-action:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-runner.yml
+++ b/.github/workflows/check-runner.yml
@@ -10,8 +10,7 @@ on:
       
 jobs:
   build-and-publish:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/encrypted-backups.yml
+++ b/.github/workflows/encrypted-backups.yml
@@ -10,8 +10,7 @@ on:
       
 jobs:
   build-and-publish-encrypted-backups:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ha-linky.yml
+++ b/.github/workflows/ha-linky.yml
@@ -9,8 +9,7 @@ on:
       
 jobs:
   checkout-code:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/internal-linking.yml
+++ b/.github/workflows/internal-linking.yml
@@ -10,8 +10,7 @@ on:
       
 jobs:
   build-and-publish:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/jekyll-version-drift-check.yml
+++ b/.github/workflows/jekyll-version-drift-check.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   check-versions:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       report: ${{ steps.check.outputs.report }}
       has_drift: ${{ steps.check.outputs.has_drift }}
@@ -156,7 +156,7 @@ jobs:
 
   notify:
     needs: check-versions
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     if: ${{ needs.check-versions.outputs.has_drift == 'true' || github.event.inputs.send_report == 'true' }}
     steps:
       - name: Create issue if drift detected

--- a/.github/workflows/keyword-suggestion.yml
+++ b/.github/workflows/keyword-suggestion.yml
@@ -10,8 +10,7 @@ on:
       
 jobs:
   build-and-publish-keyword-suggestion:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/latextcv.yml
+++ b/.github/workflows/latextcv.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/openai-generate-blogpost.yml
+++ b/.github/workflows/openai-generate-blogpost.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/post_paraphraser.yml
+++ b/.github/workflows/post_paraphraser.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/post_summarizer.yml
+++ b/.github/workflows/post_summarizer.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/reusable-auto-internal-linking.yml
+++ b/.github/workflows/reusable-auto-internal-linking.yml
@@ -54,7 +54,7 @@ on:
 
 jobs:
   check-runner:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}
 

--- a/.github/workflows/reusable-automoveandpublish-posts.yml
+++ b/.github/workflows/reusable-automoveandpublish-posts.yml
@@ -130,7 +130,7 @@ env:
 
 jobs:
   check-runner:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}
 

--- a/.github/workflows/reusable_commit-generated-files.yml
+++ b/.github/workflows/reusable_commit-generated-files.yml
@@ -66,7 +66,7 @@ on:
 
 jobs:
   commit-files:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       changes_committed: ${{ steps.commit.outputs.changes_committed }}
       files_changed: ${{ steps.check_files.outputs.files_changed }}

--- a/.github/workflows/reusable_crm-support-setup.yml
+++ b/.github/workflows/reusable_crm-support-setup.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   setup-crm:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -190,7 +190,7 @@ jobs:
 
   setup-support:
     if: ${{ inputs.setup_support }}
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_deploy-application.yml
+++ b/.github/workflows/reusable_deploy-application.yml
@@ -156,7 +156,7 @@ on:
 
 jobs:
   route-deployment:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       status: ${{ steps.set-output.outputs.status }}
       url: ${{ steps.set-output.outputs.url }}

--- a/.github/workflows/reusable_deploy-jekyll-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-jekyll-to-o2switch.yml
@@ -139,7 +139,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       deployment_status: ${{ steps.set-result.outputs.status }}
       deployed_url: ${{ steps.set-result.outputs.url }}

--- a/.github/workflows/reusable_deploy-nodejs-ssh-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-nodejs-ssh-to-o2switch.yml
@@ -208,7 +208,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       deployment_status: ${{ steps.set-result.outputs.status }}
       deployed_url: ${{ steps.set-result.outputs.url }}

--- a/.github/workflows/reusable_deploy-to-aws.yml
+++ b/.github/workflows/reusable_deploy-to-aws.yml
@@ -147,7 +147,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       status: ${{ steps.result.outputs.status }}
       url: ${{ steps.result.outputs.url }}

--- a/.github/workflows/reusable_deploy-to-azure.yml
+++ b/.github/workflows/reusable_deploy-to-azure.yml
@@ -109,7 +109,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       status: ${{ steps.result.outputs.status }}
       url: ${{ steps.result.outputs.url }}

--- a/.github/workflows/reusable_deploy-to-gcp.yml
+++ b/.github/workflows/reusable_deploy-to-gcp.yml
@@ -190,7 +190,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       status: ${{ steps.result.outputs.status }}
       url: ${{ steps.result.outputs.url }}

--- a/.github/workflows/reusable_deploy-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-to-o2switch.yml
@@ -139,7 +139,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       deployment_status: ${{ steps.deploy_result.outputs.status }}
       app_url: ${{ steps.deploy_result.outputs.url }}

--- a/.github/workflows/reusable_deploy-wordpress-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-wordpress-to-o2switch.yml
@@ -87,7 +87,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       deployment_status: ${{ steps.set-result.outputs.status }}
 

--- a/.github/workflows/reusable_gapps-deploy-dev.yml
+++ b/.github/workflows/reusable_gapps-deploy-dev.yml
@@ -68,7 +68,7 @@ on:
 jobs:
   deploy-dev:
     name: 🚀 Deploy to Dev
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       deployment_id: ${{ steps.deploy.outputs.deployment_id }}
       deployment_url: ${{ steps.build-url.outputs.url }}

--- a/.github/workflows/reusable_gapps-deploy-production.yml
+++ b/.github/workflows/reusable_gapps-deploy-production.yml
@@ -72,7 +72,7 @@ on:
 jobs:
   deploy-production:
     name: 🚀 Deploy to Production
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       deployment_id: ${{ steps.deploy.outputs.deployment_id }}
       deployment_url: ${{ steps.build-url.outputs.url }}

--- a/.github/workflows/reusable_gapps-rollback.yml
+++ b/.github/workflows/reusable_gapps-rollback.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   rollback:
     name: 🔄 Execute Rollback
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     environment:
       name: ${{ inputs.environment }}
 

--- a/.github/workflows/reusable_indexation-issues.yml
+++ b/.github/workflows/reusable_indexation-issues.yml
@@ -92,7 +92,7 @@ on:
 
 jobs:
   analyze-indexation:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       total_issues_found: ${{ steps.run-analysis.outputs.total_issues_found }}
       critical_issues: ${{ steps.run-analysis.outputs.critical_issues }}

--- a/.github/workflows/reusable_keywordsuggestionandytvidsposts.yml
+++ b/.github/workflows/reusable_keywordsuggestionandytvidsposts.yml
@@ -181,7 +181,7 @@ on:
 
 jobs:
   check-runner:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}
 

--- a/.github/workflows/reusable_marketing-tools-setup.yml
+++ b/.github/workflows/reusable_marketing-tools-setup.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   setup-mautic:
     if: ${{ inputs.setup_mautic }}
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -225,7 +225,7 @@ jobs:
 
   setup-matomo:
     if: ${{ inputs.setup_matomo }}
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_openaigenerateblogpost.yml
+++ b/.github/workflows/reusable_openaigenerateblogpost.yml
@@ -124,7 +124,7 @@ on:
 
 jobs:
   check-runner:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     outputs:
       runner-label: ${{ steps.set-runner.outputs.runner-label }}
 

--- a/.github/workflows/reusable_product-infrastructure-setup.yml
+++ b/.github/workflows/reusable_product-infrastructure-setup.yml
@@ -84,8 +84,7 @@ env:
 
 jobs:
   setup-infrastructure:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_retire-posts.yml
+++ b/.github/workflows/reusable_retire-posts.yml
@@ -33,8 +33,7 @@ permissions:
 
 jobs:
   retire-posts:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - name: Checkout calling repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_social-generate.yml
+++ b/.github/workflows/reusable_social-generate.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   generate:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/reusable_social-publish.yml
+++ b/.github/workflows/reusable_social-publish.yml
@@ -37,7 +37,7 @@ on:
 
 jobs:
   publish:
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     permissions:
       contents: write
     outputs:

--- a/.github/workflows/seo-analysis.yml
+++ b/.github/workflows/seo-analysis.yml
@@ -9,8 +9,7 @@ on:
       
 jobs:
   build-and-publish-seo-analysis:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/set-runner-mode.yml
+++ b/.github/workflows/set-runner-mode.yml
@@ -1,0 +1,114 @@
+name: "Set Runner Mode (Failover Control)"
+
+# Run this workflow when your self-hosted runner goes down or comes back up.
+# It updates the RUNNER_LABEL variable across all BrightSoftwares repos so
+# every workflow automatically uses the correct runner on next trigger.
+#
+# Requirements:
+#   - Secret RUNNER_CONTROL_PAT must be set in this repo's secrets.
+#     PAT scopes needed: repo (for private repos) or public_repo (public only).
+#
+# Usage:
+#   - Self-hosted going down  → dispatch with mode = ubuntu-latest
+#   - Self-hosted back online → dispatch with mode = self-hosted
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Runner to use across all repos"
+        required: true
+        type: choice
+        options:
+          - self-hosted
+          - ubuntu-latest
+
+jobs:
+  propagate:
+    # MUST run on github-hosted — self-hosted may be offline when you need this
+    runs-on: ubuntu-latest
+    steps:
+      - name: Propagate RUNNER_LABEL to all repos
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_CONTROL_PAT }}
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -e
+          REPOS=(
+            "BrightSoftwares/eagles-techs.com"
+            "BrightSoftwares/foolywise.com"
+            "BrightSoftwares/ieatmyhealth.com"
+            "BrightSoftwares/keke.li"
+            "BrightSoftwares/modabyflora-corporate"
+            "BrightSoftwares/olympics-paris2024.com"
+            "BrightSoftwares/joyousbyflora-posts"
+            "BrightSoftwares/corporate-website"
+            "BrightSoftwares/notiwise"
+            "BrightSoftwares/pilotflow-with-zippy"
+            "BrightSoftwares/smart-assets-manager"
+            "BrightSoftwares/hognekaba-backend"
+            "BrightSoftwares/n8n-heroku"
+            "BrightSoftwares/transaction-taxonomy"
+            "BrightSoftwares/duolingo-clone"
+            "BrightSoftwares/blogpost-tools"
+          )
+
+          SUCCESS=0
+          FAILED=0
+
+          for REPO in "${REPOS[@]}"; do
+            # Check if variable already exists
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${REPO}/actions/variables/RUNNER_LABEL")
+
+            if [ "$STATUS" = "200" ]; then
+              # Update existing variable
+              HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X PATCH \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${REPO}/actions/variables/RUNNER_LABEL" \
+                -d "{\"value\":\"${MODE}\"}")
+              ACTION="updated"
+            else
+              # Create new variable
+              HTTP=$(curl -s -o /dev/null -w "%{http_code}" \
+                -X POST \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${REPO}/actions/variables" \
+                -d "{\"name\":\"RUNNER_LABEL\",\"value\":\"${MODE}\"}")
+              ACTION="created"
+            fi
+
+            if [[ "$HTTP" =~ ^2 ]]; then
+              echo "✓ ${REPO} — RUNNER_LABEL=${MODE} (${ACTION})"
+              SUCCESS=$((SUCCESS + 1))
+            else
+              echo "✗ ${REPO} — HTTP ${HTTP} (${ACTION} failed)"
+              FAILED=$((FAILED + 1))
+            fi
+          done
+
+          echo ""
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "Result: ${SUCCESS} succeeded, ${FAILED} failed"
+          echo "RUNNER_LABEL is now: ${MODE}"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::warning::${FAILED} repo(s) failed to update. Check PAT permissions."
+            exit 1
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Runner Mode Change" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**New mode:** \`${{ inputs.mode }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "All workflow \`runs-on\` fields use \`vars.RUNNER_LABEL\` with \`self-hosted\` fallback." >> $GITHUB_STEP_SUMMARY
+          echo "Changes take effect on the **next trigger** of each workflow (no re-runs needed)." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/translate-blogpost.yml
+++ b/.github/workflows/translate-blogpost.yml
@@ -10,8 +10,7 @@ on:
       
 jobs:
   build-and-publish-keyword-suggestion:
-    runs-on: self-hosted
-
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/unsplash-to-cloudinary copy.yml
+++ b/.github/workflows/unsplash-to-cloudinary copy.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     #runs-on: self-hosted
     steps:
       - name: Check out the repo

--- a/.github/workflows/unsplash-to-cloudinary.yml
+++ b/.github/workflows/unsplash-to-cloudinary.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: self-hosted
+    runs-on: "${{ vars.RUNNER_LABEL || 'self-hosted' }}"
     #runs-on: self-hosted
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Replaces hard-coded 'self-hosted' with '${{ vars.RUNNER_LABEL || '\''self-hosted'\'' }}' so that toggling the repo-level variable RUNNER_LABEL switches the runner between self-hosted and ubuntu-latest without touching workflow files.

Propagation workflow (set-runner-mode.yml) added to blogpost-tools to update RUNNER_LABEL across all repos via a single workflow_dispatch.

Proxmox-bound jobs are untouched (must never fall back to GitHub-hosted). Parameterised reusable workflows (runs-on: ${{ inputs.runner }}) left unchanged — their callers' input values were updated instead.

https://github.com/sergioafanou/my-obsidian