### PR TITLE
feat(workflows): add workflow_dispatch to all 19 reusable workflows

### DIFF
--- a/.github/workflows/build_and_publish_docker.yml
+++ b/.github/workflows/build_and_publish_docker.yml
@@ -1,6 +1,7 @@
 name: Build and Publish Docker image
   
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       image_name:

--- a/.github/workflows/reusable-jekyll-build.yml
+++ b/.github/workflows/reusable-jekyll-build.yml
@@ -1,6 +1,7 @@
 name: Reusable Jekyll Build
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       ruby-version:

--- a/.github/workflows/reusable_commit-generated-files.yml
+++ b/.github/workflows/reusable_commit-generated-files.yml
@@ -1,6 +1,7 @@
 name: Commit Generated Files
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       commit_message_prefix:

--- a/.github/workflows/reusable_deploy-application.yml
+++ b/.github/workflows/reusable_deploy-application.yml
@@ -4,6 +4,7 @@ name: Deploy Application (Master Orchestrator)
 # Automatically selects the appropriate deployment workflow based on hosting_provider input
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       app_name:

--- a/.github/workflows/reusable_deploy-jekyll-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-jekyll-to-o2switch.yml
@@ -24,6 +24,7 @@ name: Deploy Jekyll Site to o2switch via FTP/SFTP
 #         CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID_IEATMYHEALTH }}
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       # Jekyll build options

--- a/.github/workflows/reusable_deploy-nodejs-ssh-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-nodejs-ssh-to-o2switch.yml
@@ -49,6 +49,7 @@ name: Deploy Node.js App to o2switch via SSH (with cPanel API Token whitelist)
 #         CPANEL_API_TOKEN: ${{ secrets.O2SWITCH_CPANEL_API_TOKEN }}
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       # App identity

--- a/.github/workflows/reusable_deploy-to-aws.yml
+++ b/.github/workflows/reusable_deploy-to-aws.yml
@@ -5,6 +5,7 @@ name: Deploy Application to AWS
 # This workflow is idempotent - checks if resources exist before creating
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       app_name:

--- a/.github/workflows/reusable_deploy-to-azure.yml
+++ b/.github/workflows/reusable_deploy-to-azure.yml
@@ -5,6 +5,7 @@ name: Deploy Application to Microsoft Azure
 # This workflow is idempotent - checks if resources exist before creating
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       app_name:

--- a/.github/workflows/reusable_deploy-to-gcp.yml
+++ b/.github/workflows/reusable_deploy-to-gcp.yml
@@ -5,6 +5,7 @@ name: Deploy Application to Google Cloud Platform
 # This workflow is idempotent - checks if resources exist before creating
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       app_name:

--- a/.github/workflows/reusable_deploy-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-to-o2switch.yml
@@ -4,6 +4,7 @@ name: Deploy Application to o2switch/cPanel
 # This workflow is idempotent - it checks if the application is already deployed before proceeding
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       app_name:

--- a/.github/workflows/reusable_deploy-wordpress-to-o2switch.yml
+++ b/.github/workflows/reusable_deploy-wordpress-to-o2switch.yml
@@ -23,6 +23,7 @@ name: Deploy WordPress to o2switch via FTP/SFTP
 #         FTP_PASSWORD: ${{ secrets.O2SWITCH_FTP_PASSWORD }}
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       domain_name:

--- a/.github/workflows/reusable_gapps-deploy-dev.yml
+++ b/.github/workflows/reusable_gapps-deploy-dev.yml
@@ -1,6 +1,7 @@
 name: 🚀 Deploy Google Apps Script to Development
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       script_id:

--- a/.github/workflows/reusable_gapps-deploy-production.yml
+++ b/.github/workflows/reusable_gapps-deploy-production.yml
@@ -1,6 +1,7 @@
 name: 🚀 Deploy Google Apps Script to Production
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       script_id:

--- a/.github/workflows/reusable_gapps-rollback.yml
+++ b/.github/workflows/reusable_gapps-rollback.yml
@@ -1,6 +1,7 @@
 name: 🔄 Rollback Google Apps Script Deployment
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       script_id:

--- a/.github/workflows/reusable_indexation-issues.yml
+++ b/.github/workflows/reusable_indexation-issues.yml
@@ -3,6 +3,7 @@ name: Analyze indexation and fix issues
 
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       site_url:

--- a/.github/workflows/reusable_jekyll_build_and_deploy.yml
+++ b/.github/workflows/reusable_jekyll_build_and_deploy.yml
@@ -1,6 +1,7 @@
 name: Reusable Jekyll Build and Deploy
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       # Jekyll build options

--- a/.github/workflows/reusable_retire-posts.yml
+++ b/.github/workflows/reusable_retire-posts.yml
@@ -1,6 +1,7 @@
 name: Reusable Retire Posts
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       retire_queue_file:

--- a/.github/workflows/reusable_social-generate.yml
+++ b/.github/workflows/reusable_social-generate.yml
@@ -1,6 +1,7 @@
 name: Social Generate (reusable)
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       posts_dir:

--- a/.github/workflows/reusable_social-publish.yml
+++ b/.github/workflows/reusable_social-publish.yml
@@ -1,6 +1,7 @@
 name: Social Publish (reusable)
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       drafts_dir:


### PR DESCRIPTION
Enables on-demand triggering of every reusable workflow directly from the GitHub Actions UI for testing and debugging without waiting for a caller workflow to fire. Adds workflow_dispatch: to: build_and_publish_docker, reusable-jekyll-build, reusable_commit-generated-files, reusable_deploy-application, reusable_deploy-jekyll-to-o2switch, reusable_deploy-nodejs-ssh-to-o2switch, reusable_deploy-to-{aws,azure,gcp,o2switch}, reusable_deploy-wordpress-to-o2switch, reusable_gapps-{deploy-dev,deploy-production,rollback}, reusable_indexation-issues, reusable_jekyll_build_and_deploy, reusable_retire-posts, reusable_social-{generate,publish}.

>>> Completed: gh8disp6-2 — all 29 reusable workflows now have workflow_dispatch
>>> Next: human merges claude/automated-work → main in blogpost-tools

https://claude.ai/code/session_01MZKosbzH1tsxH3yW6gPCbj